### PR TITLE
removing repetitive content in park_views and photo_views

### DIFF
--- a/views/park_views.py
+++ b/views/park_views.py
@@ -1,13 +1,11 @@
-import sqlite3
 from models import Parks
+from sql_helper import get_all, get_single
 
 def get_all_parks():
-    """getting all of the parks and their data"""
-    with sqlite3.connect("./national_park.sqlite3") as conn:
-        conn.row_factory = sqlite3.Row
-        db_cursor = conn.cursor()
+    """Gets all parks
+        Returns: a list of all park dictionaries"""
 
-        db_cursor.execute("""
+    sql= """
         SELECT
             p.id,
             p.name,
@@ -17,25 +15,21 @@ def get_all_parks():
             p.latitude,
             p.longitude,
         FROM parks p
-        """)
+        """
 
-        parks = []
+    parks = []
 
-        dataset = db_cursor.fetchall()
+    dataset = get_all(sql)
 
-        for row in dataset:
-            park = Parks(row['id'], row['name'], row['history'], row['city'], row['state'], row['latitude'], row['longitude'])
-            parks.append(park.__dict__)
+    for row in dataset:
+        park = Parks(row['id'], row['name'], row['history'], row['city'], row['state'], row['latitude'], row['longitude'])
+        parks.append(park.__dict__)
         
-        return parks
+    return parks
 
 def get_single_park(id):
-    """getting one park by id"""
-    with sqlite3.connect("./national_park.sqlite3") as conn:
-        conn.row_factory = sqlite3.Row
-        db_cursor = conn.cursor()
-
-        db_cursor.execute("""
+    """finds the matching park dictionary for the specified park id"""
+    sql = """
         SELECT
             p.id,
             p.name,
@@ -46,14 +40,10 @@ def get_single_park(id):
             p.longitude,
         FROM parks p
         WHERE p.id = ?
-        """, ( id, ))
+        """
 
-        parks = []
+    data = get_single(sql, id)
 
-        data = db_cursor.fetchone()
+    park = Parks(data['id'], data['name'], data['history'], data['city'], data['state'], data['latitude'], data['longitude'])
 
-        park = Parks(data['id'], data['name'], data['history'], data['city'], data['state'], data['latitude'], data['longitude'])
-
-        parks.append(park.__dict__)
-
-        return parks
+    return park.__dict__

--- a/views/park_views.py
+++ b/views/park_views.py
@@ -13,7 +13,7 @@ def get_all_parks():
             p.city,
             p.state,
             p.latitude,
-            p.longitude,
+            p.longitude
         FROM parks p
         """
 
@@ -37,7 +37,7 @@ def get_single_park(id):
             p.city,
             p.state,
             p.latitude,
-            p.longitude,
+            p.longitude
         FROM parks p
         WHERE p.id = ?
         """

--- a/views/photo_views.py
+++ b/views/photo_views.py
@@ -1,38 +1,41 @@
-import sqlite3
 from models import Photos
+from sql_helper import get_all, get_single
 
 def get_all_photos():
-    "getting all of the photos"
-    with sqlite3.connect("./national_park.sqlite3") as conn:
-        conn.row_factory = sqlite3.Row
-        db_cursor = conn.cursor()
+    """Gets all photos
+    Returns:
+        list: All photo dictionaries"""
 
-        db_cursor.execute("""
+    sql = """
         SELECT
             p.id,
             p.url,
             p.user_id,
             p.park_id,
         FROM photos p
-        """)
+        """
 
-        photos = []
+    photos = []
 
-        dataset = db_cursor.fetchall()
+    dataset = get_all(sql)
 
-        for row in dataset:
-            photo = Photos(row['id'], row['url'], row['user_id'], row['park_id'])
-            photos.append(photo.__dict__)
-        
-        return photos
+    for row in dataset:
+        photo = Photos(row['id'], row['url'], row['user_id'], row['park_id'])
+        photos.append(photo.__dict__)
+
+    return photos
 
 def get_single_photo(id):
-    """to get a single photo by id"""
-    with sqlite3.connect("./national_park.sqlite3") as conn:
-        conn.row_factory = sqlite3.Row
-        db_cursor = conn.cursor()
+    """Finds the matching photo dictionary for the specified photo id
 
-        db_cursor.execute("""
+    Args:
+        id (int): photo id
+
+    Returns:
+        dict: photo dictionary
+    """
+
+    sql = """
         SELECT
             p.id,
             p.url,
@@ -40,15 +43,39 @@ def get_single_photo(id):
             p.park_id,
         FROM photos p
         WHERE p.id = ?
-        """, ( id, ))
+        """
 
-        photos = []
+    data = get_single(sql, id)
 
-        data = db_cursor.fetchone()
+    photo = Photos(data['id'], data['url'], data['user_id'], data['park_id'])
 
-        photo = Photos(data['id'], data['url'], data['user_id'], data['park_id'])
+    return photo.__dict__
 
-        photos.append(photo.__dict__)
+def get_photos_by_user_id(user_id):
+    """Accepts user_id as a parameter, then sends it in the sql variable as a parameter to get_all
 
-        return photos
+    Args:
+        user_id (int): foreign key to show each user their own uploaded images
 
+    Returns:
+        list: of all photos associated with the user_id foreign key
+    """
+
+    sql=("""
+       SELECT
+            p.id,
+            p.url,
+            p.user_id,
+            p.park_id,
+        FROM photos p
+        WHERE user_id = ?
+        """, ( user_id, ))
+
+    photos = []
+
+    dataset = get_all(sql)
+
+    for row in dataset:
+        photo = Photos(row['id'], row['url'], row['user_id'], row['park_id'])
+        photos.append(photo.__dict__)       
+    return photos

--- a/views/photo_views.py
+++ b/views/photo_views.py
@@ -66,7 +66,7 @@ def get_photos_by_user_id(user_id):
             p.id,
             p.url,
             p.user_id,
-            p.park_id,
+            p.park_id
         FROM photos p
         WHERE user_id = ?
         """, ( user_id, ))

--- a/views/photo_views.py
+++ b/views/photo_views.py
@@ -11,7 +11,7 @@ def get_all_photos():
             p.id,
             p.url,
             p.user_id,
-            p.park_id,
+            p.park_id
         FROM photos p
         """
 
@@ -40,7 +40,7 @@ def get_single_photo(id):
             p.id,
             p.url,
             p.user_id,
-            p.park_id,
+            p.park_id
         FROM photos p
         WHERE p.id = ?
         """


### PR DESCRIPTION
**Description**
Implemented sql helper functions into parks and photos by  removing sql connection code from each module and inserting the get_all() and get_single() helper functions where appropriate. get_all and get_single were imported from sql_helper.py.
Added a get_photo_by_user_id function

**Steps to test get_all**
Fetch the sc-updating_get branch and switch to it
Start/restart debugger
Send a GET request for all parks data (e.g. http://localhost:8088/parks)
Verify that 200 status code and the entire list of dictionaries are received
Repeat process for the following GET requests:
http://localhost:8088/photos

**Steps to test get_single**
Fetch the sc-updating_get branch and switch to it
Start/restart debugger
Send a GET request for an existing park(e.g. http://localhost:8088/parks/1)
Verify that 200 status code and the single dictionary with id = 1 are received
Repeat process for the following GET requests:
http://localhost:8088/photos/1

**Steps to test get_photo_by_user_id**
Fetch the sc-updating_get branch and switch to it
Start/restart debugger
Send a GET request for existing photos with user_id = 1 (http://localhost:8088/photos?user_id=1)
Verify that 200 status code and the single dictionary with id = 1 are received

